### PR TITLE
Plugin report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-**Finds and reports usage of deprecated Jenkins api in plugins** (except api used in jelly and groovy files and in WEB-INF/lib/*.jar)
+**Finds and reports usage of**
+* **deprecated Jenkins api in plugins** (except api used in jelly and groovy files and in WEB-INF/lib/*.jar)
+* **deprecated plugin api in dependent plugins**
 
-[![Build Status](https://ci.jenkins-ci.org/buildStatus/icon?job=Reporting/infra_deprecated-usage-in-plugins)](https://ci.jenkins-ci.org/view/All/job/Reporting/job/infra_deprecated-usage-in-plugins/)
+[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Reporting/deprecated-usage-in-plugins)](https://ci.jenkins.io/job/Reporting/job/deprecated-usage-in-plugins/)
 
 Current results in summary:
 * 1114 plugins
@@ -8,7 +10,7 @@ Current results in summary:
 * 20 deprecated classes, 170 deprecated methods and 12 deprecated fields are used in plugins
 * 28 deprecated and public Jenkins classes, 319 deprecated methods, 58 deprecated fields are not used in the latest published plugins
 
-See details and deprecated usage for each plugin in the [continuous integration](https://ci.jenkins-ci.org/view/All/job/Reporting/job/infra_deprecated-usage-in-plugins/lastSuccessfulBuild/artifact/target/output.html) or in this [example of output](../../blob/master/Output_example.html).
+See details and deprecated usage for each plugin in the [continuous integration](https://ci.jenkins.io/job/Reporting/job/deprecated-usage-in-plugins/lastSuccessfulBuild/artifact/output/).
 
 See also:
 * [Jenkins policy for API deprecation](https://issues.jenkins-ci.org/browse/JENKINS-31035)

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.3</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/org/jenkinsci/deprecatedusage/Analysis.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Analysis.java
@@ -1,0 +1,17 @@
+package org.jenkinsci.deprecatedusage;
+
+import java.io.File;
+import java.util.List;
+
+public interface Analysis {
+    String getAnalyzedFileName();
+
+    JenkinsFile getAnalyzedFile(UpdateCenter updateCenter);
+
+    String getDependentFilesName();
+
+    List<JenkinsFile> getDependentFiles(UpdateCenter updateCenter);
+
+    File getOutputDirectory(String baseDir);
+}
+

--- a/src/main/java/org/jenkinsci/deprecatedusage/Analysis.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Analysis.java
@@ -17,5 +17,7 @@ public interface Analysis {
     boolean areSignatureFiltered();
 
     boolean skipIfNoDeprecatedApis();
+
+    JavadocUtil getJavadocUtil();
 }
 

--- a/src/main/java/org/jenkinsci/deprecatedusage/Analysis.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Analysis.java
@@ -15,5 +15,7 @@ public interface Analysis {
     File getOutputDirectory(String baseDir);
 
     boolean areSignatureFiltered();
+
+    boolean skipIfNoDeprecatedApis();
 }
 

--- a/src/main/java/org/jenkinsci/deprecatedusage/Analysis.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Analysis.java
@@ -13,5 +13,7 @@ public interface Analysis {
     List<JenkinsFile> getDependentFiles(UpdateCenter updateCenter);
 
     File getOutputDirectory(String baseDir);
+
+    boolean areSignatureFiltered();
 }
 

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedApi.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedApi.java
@@ -63,6 +63,10 @@ public class DeprecatedApi {
                 ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
     }
 
+    public boolean hasDeprecatedApis() {
+        return !classes.isEmpty() || !methods.isEmpty() || !fields.isEmpty();
+    }
+
     public Set<String> getClasses() {
         return  classes;
     }

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedApi.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedApi.java
@@ -44,15 +44,12 @@ public class DeprecatedApi {
     }
 
     public void analyze(File coreFile) throws IOException {
-        final WarReader warReader = new WarReader(coreFile, false);
-        try {
+        try (WarReader warReader = new WarReader(coreFile, false)) {
             String fileName = warReader.nextClass();
             while (fileName != null) {
                 analyze(warReader.getInputStream());
                 fileName = warReader.nextClass();
             }
-        } finally {
-            warReader.close();
         }
         classes.removeAll(IGNORED_DEPRECATED_CLASSES);
     }

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUnusedApiReport.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUnusedApiReport.java
@@ -10,8 +10,11 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 public class DeprecatedUnusedApiReport extends Report {
-    public DeprecatedUnusedApiReport(DeprecatedApi api, List<DeprecatedUsage> usages, File outputDir, String reportName) {
+    private final boolean onlyRelevantSignatures;
+    public DeprecatedUnusedApiReport(DeprecatedApi api, List<DeprecatedUsage> usages, File outputDir, String reportName,
+                                     boolean onlyRelevantSignatures) {
         super(api, usages, outputDir, reportName);
+        this.onlyRelevantSignatures = onlyRelevantSignatures;
     }
 
     protected void generateHtmlReport(Writer writer) throws IOException {
@@ -127,6 +130,9 @@ public class DeprecatedUnusedApiReport extends Report {
     }
 
     private boolean isRelevantSignature(String signature) {
+        if (!onlyRelevantSignatures) {
+            return true;
+        }
         if (signature.contains("jenkins")) {
             return true;
         }

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUnusedApiReport.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUnusedApiReport.java
@@ -11,9 +11,8 @@ import java.util.TreeSet;
 
 public class DeprecatedUnusedApiReport extends Report {
     private final boolean onlyRelevantSignatures;
-    public DeprecatedUnusedApiReport(DeprecatedApi api, List<DeprecatedUsage> usages, File outputDir, String reportName,
-                                     boolean onlyRelevantSignatures) {
-        super(api, usages, outputDir, reportName);
+    public DeprecatedUnusedApiReport(DeprecatedApi api, List<DeprecatedUsage> usages, File outputDir, String reportName, JavadocUtil javadocUtil, boolean onlyRelevantSignatures) {
+        super(api, usages, outputDir, reportName, javadocUtil);
         this.onlyRelevantSignatures = onlyRelevantSignatures;
     }
 
@@ -32,7 +31,7 @@ public class DeprecatedUnusedApiReport extends Report {
                         continue CLASSES;
                     }
                 }
-                writer.append("<li>").append(JavadocUtil.signatureToJenkinsdocLink(deprecatedClass)).append("</li>\n");
+                writer.append("<li>").append(javadocUtil.signatureToJenkinsdocLink(deprecatedClass)).append("</li>\n");
             }
             writer.append("</div>");
         }
@@ -49,7 +48,7 @@ public class DeprecatedUnusedApiReport extends Report {
                         continue FIELDS;
                     }
                 }
-                writer.append("<li>").append(JavadocUtil.signatureToJenkinsdocLink(deprecatedField)).append("</li>\n");
+                writer.append("<li>").append(javadocUtil.signatureToJenkinsdocLink(deprecatedField)).append("</li>\n");
             }
             writer.append("</div>");
         }
@@ -66,7 +65,7 @@ public class DeprecatedUnusedApiReport extends Report {
                         continue METHODS;
                     }
                 }
-                writer.append("<li>").append(JavadocUtil.signatureToJenkinsdocLink(deprecatedMethod)).append("</li>\n");
+                writer.append("<li>").append(javadocUtil.signatureToJenkinsdocLink(deprecatedMethod)).append("</li>\n");
             }
             writer.append("</div>");
         }

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUnusedApiReport.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUnusedApiReport.java
@@ -32,7 +32,7 @@ public class DeprecatedUnusedApiReport extends Report {
                         continue CLASSES;
                     }
                 }
-                writer.append("<li>" + JavadocUtil.signatureToJenkinsdocLink(deprecatedClass) + "</li>\n");
+                writer.append("<li>").append(JavadocUtil.signatureToJenkinsdocLink(deprecatedClass)).append("</li>\n");
             }
             writer.append("</div>");
         }
@@ -49,7 +49,7 @@ public class DeprecatedUnusedApiReport extends Report {
                         continue FIELDS;
                     }
                 }
-                writer.append("<li>" + JavadocUtil.signatureToJenkinsdocLink(deprecatedField) + "</li>\n");
+                writer.append("<li>").append(JavadocUtil.signatureToJenkinsdocLink(deprecatedField)).append("</li>\n");
             }
             writer.append("</div>");
         }
@@ -66,7 +66,7 @@ public class DeprecatedUnusedApiReport extends Report {
                         continue METHODS;
                     }
                 }
-                writer.append("<li>" + JavadocUtil.signatureToJenkinsdocLink(deprecatedMethod) + "</li>\n");
+                writer.append("<li>").append(JavadocUtil.signatureToJenkinsdocLink(deprecatedMethod)).append("</li>\n");
             }
             writer.append("</div>");
         }

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
@@ -52,15 +52,12 @@ public class DeprecatedUsage {
             throws IOException {
         // recent plugins package their classes as a jar file with the same name as the war file in
         // WEB-INF/lib/ while older plugins were packaging their classes in WEB-INF/classes/
-        final WarReader warReader = new WarReader(pluginFile, true);
-        try {
+        try (WarReader warReader = new WarReader(pluginFile, true)) {
             String fileName = warReader.nextClass();
             while (fileName != null) {
                 analyze(warReader.getInputStream(), aClassVisitor);
                 fileName = warReader.nextClass();
             }
-        } finally {
-            warReader.close();
         }
 
         // final InputStream input = new FileInputStream(pluginFile);

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByApiReport.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByApiReport.java
@@ -80,9 +80,9 @@ public class DeprecatedUsageByApiReport extends Report {
             writer.append("<h2>Classes</h2>\n");
             for (Map.Entry<String, SortedSet<String>> entry : deprecatedClassesToPlugins.entrySet()) {
                 writer.append("<div class='class'>\n");
-                writer.append("<h3 id='" + entry.getKey().replaceAll("[^a-zA-Z0-9-]", "_") + "'>" + JavadocUtil.signatureToJenkinsdocLink(entry.getKey()) + "</h3><ul>\n");
+                writer.append("<h3 id='").append(entry.getKey().replaceAll("[^a-zA-Z0-9-]", "_")).append("'>").append(JavadocUtil.signatureToJenkinsdocLink(entry.getKey())).append("</h3><ul>\n");
                 for (String plugin : entry.getValue()) {
-                    writer.append("<li><a href='http://plugins.jenkins.io/" + plugin + "'>" + plugin + "</a></li>\n");
+                    writer.append("<li><a href='http://plugins.jenkins.io/").append(plugin).append("'>").append(plugin).append("</a></li>\n");
                 }
                 writer.append("</ul></div>\n\n");
             }
@@ -92,9 +92,9 @@ public class DeprecatedUsageByApiReport extends Report {
             writer.append("<h2>Fields</h2>\n");
             for (Map.Entry<String, SortedSet<String>> entry : deprecatedFieldsToPlugins.entrySet()) {
                 writer.append("<div class='field'>\n");
-                writer.append("<h3 id='" + entry.getKey().replaceAll("[^a-zA-Z0-9-]", "_") + "'>" + JavadocUtil.signatureToJenkinsdocLink(entry.getKey()) + "</h3><ul>\n");
+                writer.append("<h3 id='").append(entry.getKey().replaceAll("[^a-zA-Z0-9-]", "_")).append("'>").append(JavadocUtil.signatureToJenkinsdocLink(entry.getKey())).append("</h3><ul>\n");
                 for (String plugin : entry.getValue()) {
-                    writer.append("<li><a href='http://plugins.jenkins.io/" + plugin + "'>" + plugin + "</a></li>\n");
+                    writer.append("<li><a href='http://plugins.jenkins.io/").append(plugin).append("'>").append(plugin).append("</a></li>\n");
                 }
                 writer.append("</ul></div>\n\n");
             }
@@ -104,9 +104,9 @@ public class DeprecatedUsageByApiReport extends Report {
             writer.append("<h2>Methods</h2>\n");
             for (Map.Entry<String, SortedSet<String>> entry : deprecatedMethodsToPlugins.entrySet()) {
                 writer.append("<div class='method'>\n");
-                writer.append("<h3 id='" + entry.getKey().replaceAll("[^a-zA-Z0-9-]", "_") + "'>" + JavadocUtil.signatureToJenkinsdocLink(entry.getKey()) + "</h3><ul>\n");
+                writer.append("<h3 id='").append(entry.getKey().replaceAll("[^a-zA-Z0-9-]", "_")).append("'>").append(JavadocUtil.signatureToJenkinsdocLink(entry.getKey())).append("</h3><ul>\n");
                 for (String plugin : entry.getValue()) {
-                    writer.append("<li><a href='http://plugins.jenkins.io/" + plugin + "'>" + plugin + "</a></li>\n");
+                    writer.append("<li><a href='http://plugins.jenkins.io/").append(plugin).append("'>").append(plugin).append("</a></li>\n");
                 }
                 writer.append("</ul></div>\n\n");
             }

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByApiReport.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByApiReport.java
@@ -22,8 +22,8 @@ public class DeprecatedUsageByApiReport extends Report {
     private SortedMap<String, SortedSet<String>> deprecatedMethodsToPlugins = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
 
-    public DeprecatedUsageByApiReport(DeprecatedApi api, List<DeprecatedUsage> usages, File outputDir, String reportName) {
-        super(api, usages, outputDir, reportName);
+    public DeprecatedUsageByApiReport(DeprecatedApi api, List<DeprecatedUsage> usages, File outputDir, String reportName, JavadocUtil javadocUtil) {
+        super(api, usages, outputDir, reportName, javadocUtil);
 
         SortedSet<String> deprecatedClassesUsed = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         SortedSet<String> deprecatedFieldsUsed = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
@@ -80,7 +80,7 @@ public class DeprecatedUsageByApiReport extends Report {
             writer.append("<h2>Classes</h2>\n");
             for (Map.Entry<String, SortedSet<String>> entry : deprecatedClassesToPlugins.entrySet()) {
                 writer.append("<div class='class'>\n");
-                writer.append("<h3 id='").append(entry.getKey().replaceAll("[^a-zA-Z0-9-]", "_")).append("'>").append(JavadocUtil.signatureToJenkinsdocLink(entry.getKey())).append("</h3><ul>\n");
+                writer.append("<h3 id='").append(entry.getKey().replaceAll("[^a-zA-Z0-9-]", "_")).append("'>").append(javadocUtil.signatureToJenkinsdocLink(entry.getKey())).append("</h3><ul>\n");
                 for (String plugin : entry.getValue()) {
                     writer.append("<li><a href='http://plugins.jenkins.io/").append(plugin).append("'>").append(plugin).append("</a></li>\n");
                 }
@@ -92,7 +92,7 @@ public class DeprecatedUsageByApiReport extends Report {
             writer.append("<h2>Fields</h2>\n");
             for (Map.Entry<String, SortedSet<String>> entry : deprecatedFieldsToPlugins.entrySet()) {
                 writer.append("<div class='field'>\n");
-                writer.append("<h3 id='").append(entry.getKey().replaceAll("[^a-zA-Z0-9-]", "_")).append("'>").append(JavadocUtil.signatureToJenkinsdocLink(entry.getKey())).append("</h3><ul>\n");
+                writer.append("<h3 id='").append(entry.getKey().replaceAll("[^a-zA-Z0-9-]", "_")).append("'>").append(javadocUtil.signatureToJenkinsdocLink(entry.getKey())).append("</h3><ul>\n");
                 for (String plugin : entry.getValue()) {
                     writer.append("<li><a href='http://plugins.jenkins.io/").append(plugin).append("'>").append(plugin).append("</a></li>\n");
                 }
@@ -104,7 +104,7 @@ public class DeprecatedUsageByApiReport extends Report {
             writer.append("<h2>Methods</h2>\n");
             for (Map.Entry<String, SortedSet<String>> entry : deprecatedMethodsToPlugins.entrySet()) {
                 writer.append("<div class='method'>\n");
-                writer.append("<h3 id='").append(entry.getKey().replaceAll("[^a-zA-Z0-9-]", "_")).append("'>").append(JavadocUtil.signatureToJenkinsdocLink(entry.getKey())).append("</h3><ul>\n");
+                writer.append("<h3 id='").append(entry.getKey().replaceAll("[^a-zA-Z0-9-]", "_")).append("'>").append(javadocUtil.signatureToJenkinsdocLink(entry.getKey())).append("</h3><ul>\n");
                 for (String plugin : entry.getValue()) {
                     writer.append("<li><a href='http://plugins.jenkins.io/").append(plugin).append("'>").append(plugin).append("</a></li>\n");
                 }

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByPluginReport.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByPluginReport.java
@@ -20,12 +20,7 @@ public class DeprecatedUsageByPluginReport extends Report {
     }
 
     protected void generateHtmlReport(Writer writer) throws IOException {
-        SortedSet<DeprecatedUsage> set = new TreeSet<>(new Comparator<DeprecatedUsage>() {
-            @Override
-            public int compare(DeprecatedUsage o1, DeprecatedUsage o2) {
-                return o1.getPlugin().compareTo(o2.getPlugin());
-            }
-        });
+        SortedSet<DeprecatedUsage> set = new TreeSet<>(Comparator.comparing(DeprecatedUsage::getPlugin));
         set.addAll(usages);
 
         writer.append("<h1>Deprecated Usage By Plugin</h1>");
@@ -34,12 +29,12 @@ public class DeprecatedUsageByPluginReport extends Report {
             if (!usage.hasDeprecatedUsage()) {
                 continue;
             }
-            writer.append("<div class='plugin'><h2 id='" + usage.getPlugin().artifactId +"'><a href='" + usage.getPlugin().getUrl() + "'>" + usage.getPlugin().toString() + "</a></h2>");
+            writer.append("<div class='plugin'><h2 id='").append(usage.getPlugin().artifactId).append("'><a href='").append(usage.getPlugin().getUrl()).append("'>").append(usage.getPlugin().toString()).append("</a></h2>");
 
             if (usage.getClasses().size() > 0) {
                 writer.append("<h3>Classes</h3><ul>");
                 for (String clazz : usage.getClasses()) {
-                    writer.append("<li>" + JavadocUtil.signatureToJenkinsdocLink(clazz) + "</li>\n");
+                    writer.append("<li>").append(JavadocUtil.signatureToJenkinsdocLink(clazz)).append("</li>\n");
                 }
                 writer.append("</ul>\n\n");
             }
@@ -47,7 +42,7 @@ public class DeprecatedUsageByPluginReport extends Report {
             if (usage.getMethods().size() > 0) {
                 writer.append("<h3>Methods</h3><ul>");
                 for (String method : usage.getMethods()) {
-                    writer.append("<li>" + JavadocUtil.signatureToJenkinsdocLink(method) + "</li>\n");
+                    writer.append("<li>").append(JavadocUtil.signatureToJenkinsdocLink(method)).append("</li>\n");
                 }
                 writer.append("</ul>\n\n");
             }
@@ -55,7 +50,7 @@ public class DeprecatedUsageByPluginReport extends Report {
             if (usage.getFields().size() > 0) {
                 writer.append("<h3>Fields</h3><ul>");
                 for (String field : usage.getFields()) {
-                    writer.append("<li>" + JavadocUtil.signatureToJenkinsdocLink(field) + "</li>\n");
+                    writer.append("<li>").append(JavadocUtil.signatureToJenkinsdocLink(field)).append("</li>\n");
                 }
                 writer.append("</ul>\n\n");
             }

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByPluginReport.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByPluginReport.java
@@ -15,8 +15,8 @@ import java.util.TreeSet;
  * This report shows deprecated APIs in Jenkins and Stapler that are used by plugins, grouped by the plugins, listing APIs.
  */
 public class DeprecatedUsageByPluginReport extends Report {
-    public DeprecatedUsageByPluginReport(DeprecatedApi api, List<DeprecatedUsage> usages, File outputDir, String reportName) {
-        super(api, usages, outputDir, reportName);
+    public DeprecatedUsageByPluginReport(DeprecatedApi api, List<DeprecatedUsage> usages, File outputDir, String reportName, JavadocUtil javadocUtil) {
+        super(api, usages, outputDir, reportName, javadocUtil);
     }
 
     protected void generateHtmlReport(Writer writer) throws IOException {
@@ -34,7 +34,7 @@ public class DeprecatedUsageByPluginReport extends Report {
             if (usage.getClasses().size() > 0) {
                 writer.append("<h3>Classes</h3><ul>");
                 for (String clazz : usage.getClasses()) {
-                    writer.append("<li>").append(JavadocUtil.signatureToJenkinsdocLink(clazz)).append("</li>\n");
+                    writer.append("<li>").append(javadocUtil.signatureToJenkinsdocLink(clazz)).append("</li>\n");
                 }
                 writer.append("</ul>\n\n");
             }
@@ -42,7 +42,7 @@ public class DeprecatedUsageByPluginReport extends Report {
             if (usage.getMethods().size() > 0) {
                 writer.append("<h3>Methods</h3><ul>");
                 for (String method : usage.getMethods()) {
-                    writer.append("<li>").append(JavadocUtil.signatureToJenkinsdocLink(method)).append("</li>\n");
+                    writer.append("<li>").append(javadocUtil.signatureToJenkinsdocLink(method)).append("</li>\n");
                 }
                 writer.append("</ul>\n\n");
             }
@@ -50,7 +50,7 @@ public class DeprecatedUsageByPluginReport extends Report {
             if (usage.getFields().size() > 0) {
                 writer.append("<h3>Fields</h3><ul>");
                 for (String field : usage.getFields()) {
-                    writer.append("<li>").append(JavadocUtil.signatureToJenkinsdocLink(field)).append("</li>\n");
+                    writer.append("<li>").append(javadocUtil.signatureToJenkinsdocLink(field)).append("</li>\n");
                 }
                 writer.append("</ul>\n\n");
             }

--- a/src/main/java/org/jenkinsci/deprecatedusage/HttpGet.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/HttpGet.java
@@ -34,8 +34,7 @@ public class HttpGet {
             connection.setReadTimeout(READ_TIMEOUT);
         }
         try {
-            final InputStream input = connection.getInputStream();
-            try {
+            try (InputStream input = connection.getInputStream()) {
                 final byte[] buffer = new byte[50 * 1024];
                 int len = input.read(buffer);
                 while (len != -1) {
@@ -43,8 +42,6 @@ public class HttpGet {
                     len = input.read(buffer);
                 }
             } finally {
-                input.close();
-
                 if (connection instanceof HttpURLConnection) {
                     final InputStream error = ((HttpURLConnection) connection).getErrorStream();
                     if (error != null) {

--- a/src/main/java/org/jenkinsci/deprecatedusage/JarReader.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/JarReader.java
@@ -9,7 +9,6 @@ import java.util.zip.ZipInputStream;
 
 public class JarReader implements Closeable {
     private final ZipInputStream zipInputStream;
-    private ZipEntry entry;
 
     public JarReader(InputStream input) throws IOException {
         super();
@@ -17,7 +16,7 @@ public class JarReader implements Closeable {
     }
 
     public String nextClass() throws IOException {
-        entry = zipInputStream.getNextEntry();
+        ZipEntry entry = zipInputStream.getNextEntry();
         while (entry != null && !entry.getName().endsWith(".class")) {
             entry = zipInputStream.getNextEntry();
         }

--- a/src/main/java/org/jenkinsci/deprecatedusage/JavadocUtil.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/JavadocUtil.java
@@ -9,16 +9,31 @@ import java.util.regex.Pattern;
 
 public class JavadocUtil {
 
-    private static final String JAVADOC_URL = "http://javadoc.jenkins.io/";
+    private static final String CORE_JAVADOC_URL = "http://javadoc.jenkins.io/";
     // from https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.2
     // and  https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.3
     private static final String MARKER_PATTERN = "[LBCDFIJSZV\\[]";
+
+    public static final JavadocUtil CORE = new JavadocUtil(CORE_JAVADOC_URL, true);
+    public static final JavadocUtil PLUGINS = new JavadocUtil(null, false);
+
+    private final String url;
+    private final boolean includeLinks;
+
+    private JavadocUtil(String url, boolean includeLinks) {
+        this.url = url;
+        this.includeLinks = includeLinks;
+    }
 
     public String signatureToJenkinsdocLink(String fullSignature) {
         return signatureToJenkinsdocLink(fullSignature, fullSignature);
     }
 
-    public String signatureToJenkinsdocLink(String fullSignature, String label) {
+    String signatureToJenkinsdocLink(String fullSignature, String label) {
+        if (!includeLinks) {
+            return label;
+        }
+
         String url = signatureToJenkinsdocUrl(fullSignature);
 
         label = label.replace("<", "&lt;").replace(">", "&gt;");
@@ -37,11 +52,11 @@ public class JavadocUtil {
 
         if (isClass) {
             // transform package and class names, then return
-            return JAVADOC_URL + fullSignature.replace("$", ".") + ".html";
+            return CORE_JAVADOC_URL + fullSignature.replace("$", ".") + ".html";
         }
 
         if (isField) {
-            return JAVADOC_URL + fullSignature.replace("$", ".").replace("#", ".html#");
+            return CORE_JAVADOC_URL + fullSignature.replace("$", ".").replace("#", ".html#");
         }
 
         String packageName = "";
@@ -76,7 +91,7 @@ public class JavadocUtil {
             arguments = StringUtils.join(processedArgs.toArray(), "-");
         }
 
-        return JAVADOC_URL + packageName + '/' + className + ".html#" + methodName + "-" + arguments + "-";
+        return CORE_JAVADOC_URL + packageName + '/' + className + ".html#" + methodName + "-" + arguments + "-";
     }
 
     private static String scanParameterToHuman(Scanner scanner) {

--- a/src/main/java/org/jenkinsci/deprecatedusage/JavadocUtil.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/JavadocUtil.java
@@ -14,11 +14,11 @@ public class JavadocUtil {
     // and  https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.3
     private static final String MARKER_PATTERN = "[LBCDFIJSZV\\[]";
 
-    public static String signatureToJenkinsdocLink(String fullSignature) {
+    public String signatureToJenkinsdocLink(String fullSignature) {
         return signatureToJenkinsdocLink(fullSignature, fullSignature);
     }
 
-    public static String signatureToJenkinsdocLink(String fullSignature, String label) {
+    public String signatureToJenkinsdocLink(String fullSignature, String label) {
         String url = signatureToJenkinsdocUrl(fullSignature);
 
         label = label.replace("<", "&lt;").replace(">", "&gt;");
@@ -30,7 +30,7 @@ public class JavadocUtil {
         return "<a href='" + url+ "'>" + label + "</a>";
     }
 
-    public static String signatureToJenkinsdocUrl(String fullSignature) {
+    public String signatureToJenkinsdocUrl(String fullSignature) {
 
         boolean isClass = !fullSignature.contains("#");
         boolean isField = !isClass && !fullSignature.contains("(");
@@ -118,10 +118,6 @@ public class JavadocUtil {
         if (marker.equals("Z")) {
             return "boolean";
         }
-
-
-
-
 
         return marker;
     }

--- a/src/main/java/org/jenkinsci/deprecatedusage/JavadocUtil.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/JavadocUtil.java
@@ -10,6 +10,9 @@ import java.util.regex.Pattern;
 public class JavadocUtil {
 
     private static final String JAVADOC_URL = "http://javadoc.jenkins.io/";
+    // from https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.2
+    // and  https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.3
+    private static final String MARKER_PATTERN = "[LBCDFIJSZV\\[]";
 
     public static String signatureToJenkinsdocLink(String fullSignature) {
         return signatureToJenkinsdocLink(fullSignature, fullSignature);
@@ -62,8 +65,7 @@ public class JavadocUtil {
         List<String> processedArgs = new ArrayList<>();
         if (arguments.length() > 0) {
             Scanner scanner = new Scanner(arguments);
-            String markerPattern = "[LZBCIV\\[]";
-            while (scanner.hasNext(markerPattern)) {
+            while (scanner.hasNext(MARKER_PATTERN)) {
                 processedArgs.add(scanParameterToHuman(scanner));
             }
             arguments = StringUtils.join(processedArgs.toArray(), ",%20");
@@ -73,9 +75,8 @@ public class JavadocUtil {
     }
 
     private static String scanParameterToHuman(Scanner scanner) {
-        String markerPattern = "[LZBCIV\\[]";
-        
-        String marker = scanner.next(markerPattern);
+
+        String marker = scanner.next(MARKER_PATTERN);
         if (marker.equals("[")) {
             // array
             return scanParameterToHuman(scanner) + "[]";
@@ -86,14 +87,6 @@ public class JavadocUtil {
             return className.substring(0, className.length() - 1).replace("$", ".").replace("/", ".");
         }
 
-        if (marker.equals("Z")) {
-            return "boolean";
-        }
-
-        if (marker.equals("I")) {
-            return "int";
-        }
-
         if (marker.equals("B")) {
             return "byte";
         }
@@ -101,6 +94,34 @@ public class JavadocUtil {
         if (marker.equals("C")) {
             return "char";
         }
+
+        if (marker.equals("D")) {
+            return "double";
+        }
+
+        if (marker.equals("F")) {
+            return "float";
+        }
+
+        if (marker.equals("I")) {
+            return "int";
+        }
+
+        if (marker.equals("J")) {
+            return "long";
+        }
+
+        if (marker.equals("S")) {
+            return "short";
+        }
+
+        if (marker.equals("Z")) {
+            return "boolean";
+        }
+
+
+
+
 
         return marker;
     }

--- a/src/main/java/org/jenkinsci/deprecatedusage/JavadocUtil.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/JavadocUtil.java
@@ -59,7 +59,12 @@ public class JavadocUtil {
 
         String className = classMethodAndArguments.substring(0, classMethodAndArguments.indexOf("#"));
         className = className.replace("$", ".");
-        String methodName = classMethodAndArguments.substring(classMethodAndArguments.indexOf("#") + 1, classMethodAndArguments.indexOf("(")).replace("<init>", className);
+        String lastPartOfClassName = className;
+        int startOfLastPartOfClassName = className.lastIndexOf('.');
+        if (startOfLastPartOfClassName > 0) {
+            lastPartOfClassName = className.substring(startOfLastPartOfClassName + 1);
+        }
+        String methodName = classMethodAndArguments.substring(classMethodAndArguments.indexOf("#") + 1, classMethodAndArguments.indexOf("(")).replace("<init>", lastPartOfClassName);
         String arguments = classMethodAndArguments.substring(classMethodAndArguments.indexOf("(") + 1, classMethodAndArguments.indexOf(")"));
 
         List<String> processedArgs = new ArrayList<>();
@@ -68,10 +73,10 @@ public class JavadocUtil {
             while (scanner.hasNext(MARKER_PATTERN)) {
                 processedArgs.add(scanParameterToHuman(scanner));
             }
-            arguments = StringUtils.join(processedArgs.toArray(), ",%20");
+            arguments = StringUtils.join(processedArgs.toArray(), "-");
         }
 
-        return JAVADOC_URL + packageName + '/' + className + ".html#" + methodName + "%28" + arguments + "%29";
+        return JAVADOC_URL + packageName + '/' + className + ".html#" + methodName + "-" + arguments + "-";
     }
 
     private static String scanParameterToHuman(Scanner scanner) {
@@ -79,7 +84,7 @@ public class JavadocUtil {
         String marker = scanner.next(MARKER_PATTERN);
         if (marker.equals("[")) {
             // array
-            return scanParameterToHuman(scanner) + "[]";
+            return scanParameterToHuman(scanner) + ":A";
         }
 
         if (marker.equals("L")) {

--- a/src/main/java/org/jenkinsci/deprecatedusage/JenkinsCoreAnalysis.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/JenkinsCoreAnalysis.java
@@ -33,4 +33,9 @@ public class JenkinsCoreAnalysis implements Analysis {
     public boolean areSignatureFiltered() {
         return true;
     }
+
+    @Override
+    public boolean skipIfNoDeprecatedApis() {
+        return false;
+    }
 }

--- a/src/main/java/org/jenkinsci/deprecatedusage/JenkinsCoreAnalysis.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/JenkinsCoreAnalysis.java
@@ -1,0 +1,31 @@
+package org.jenkinsci.deprecatedusage;
+
+import java.io.File;
+import java.util.List;
+
+public class JenkinsCoreAnalysis implements Analysis {
+    @Override
+    public String getAnalyzedFileName() {
+        return "Jenkins";
+    }
+
+    @Override
+    public JenkinsFile getAnalyzedFile(UpdateCenter updateCenter) {
+        return updateCenter.getCore();
+    }
+
+    @Override
+    public String getDependentFilesName() {
+        return "plugins";
+    }
+
+    @Override
+    public List<JenkinsFile> getDependentFiles(UpdateCenter updateCenter) {
+        return updateCenter.getPlugins();
+    }
+
+    @Override
+    public File getOutputDirectory(String baseDir) {
+        return new File(baseDir);
+    }
+}

--- a/src/main/java/org/jenkinsci/deprecatedusage/JenkinsCoreAnalysis.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/JenkinsCoreAnalysis.java
@@ -28,4 +28,9 @@ public class JenkinsCoreAnalysis implements Analysis {
     public File getOutputDirectory(String baseDir) {
         return new File(baseDir);
     }
+
+    @Override
+    public boolean areSignatureFiltered() {
+        return true;
+    }
 }

--- a/src/main/java/org/jenkinsci/deprecatedusage/JenkinsCoreAnalysis.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/JenkinsCoreAnalysis.java
@@ -38,4 +38,9 @@ public class JenkinsCoreAnalysis implements Analysis {
     public boolean skipIfNoDeprecatedApis() {
         return false;
     }
+
+    @Override
+    public JavadocUtil getJavadocUtil() {
+        return JavadocUtil.CORE;
+    }
 }

--- a/src/main/java/org/jenkinsci/deprecatedusage/JenkinsFile.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/JenkinsFile.java
@@ -10,6 +10,7 @@ import java.net.URL;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.HashSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -36,17 +37,19 @@ public class JenkinsFile {
     private final String version;
     private final URL url;
     private final String wiki;
+    private final HashSet<String> dependencies;
     private File file;
     private final File versionsRootDirectory;
     private Future<?> downloadFuture;
 
-    public JenkinsFile(String name, String version, String url, String wiki)
+    public JenkinsFile(String name, String version, String url, String wiki, HashSet<String> dependencies)
             throws MalformedURLException {
         super();
         this.name = name;
         this.version = version;
         this.url = new URL(url);
         this.wiki = wiki;
+        this.dependencies = dependencies;
         final String fileName = url.substring(url.lastIndexOf('/'));
         this.versionsRootDirectory = new File(WORK_DIRECTORY, name);
         this.file = new File(versionsRootDirectory, version + '/' + fileName);
@@ -140,5 +143,9 @@ public class JenkinsFile {
     @Override
     public String toString() {
         return file.getName();
+    }
+
+    public boolean isDependentOn(JenkinsFile plugin) {
+        return dependencies.contains(plugin.getName());
     }
 }

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -29,6 +29,9 @@ public class Main {
         System.out.println("All files are up to date (" + updateCenter.getPlugins().size() + " plugins)");
 
         createReport(updateCenter, new JenkinsCoreAnalysis());
+        for(JenkinsFile plugin : updateCenter.getPlugins()) {
+            createReport(updateCenter, new PluginAnalysis(plugin));
+        }
 
         System.out.println("duration : " + (System.currentTimeMillis() - start) + " ms at "
                 + DateFormat.getDateTimeInstance().format(new Date()));

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -49,7 +49,7 @@ public class Main {
         File outputDir = analysis.getOutputDirectory("output");
         Report[] reports = new Report[] {
                 new DeprecatedUsageByPluginReport(deprecatedApi, deprecatedUsages, outputDir, "usage-by-plugin"),
-                new DeprecatedUnusedApiReport(deprecatedApi, deprecatedUsages, outputDir, "deprecated-and-unused"),
+                new DeprecatedUnusedApiReport(deprecatedApi, deprecatedUsages, outputDir, "deprecated-and-unused", analysis.areSignatureFiltered()),
                 new DeprecatedUsageByApiReport(deprecatedApi, deprecatedUsages, outputDir, "usage-by-api")
         };
 

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -73,10 +73,11 @@ public class Main {
         final List<DeprecatedUsage> deprecatedUsages = analyzeDeprecatedUsage(analysis.getDependentFiles(updateCenter), deprecatedApi);
 
         File outputDir = analysis.getOutputDirectory("output");
+        JavadocUtil javadocUtil = new JavadocUtil();
         Report[] reports = new Report[] {
-                new DeprecatedUsageByPluginReport(deprecatedApi, deprecatedUsages, outputDir, "usage-by-plugin"),
-                new DeprecatedUnusedApiReport(deprecatedApi, deprecatedUsages, outputDir, "deprecated-and-unused", analysis.areSignatureFiltered()),
-                new DeprecatedUsageByApiReport(deprecatedApi, deprecatedUsages, outputDir, "usage-by-api")
+                new DeprecatedUsageByPluginReport(deprecatedApi, deprecatedUsages, outputDir, "usage-by-plugin", javadocUtil),
+                new DeprecatedUnusedApiReport(deprecatedApi, deprecatedUsages, outputDir, "deprecated-and-unused", javadocUtil, analysis.areSignatureFiltered()),
+                new DeprecatedUsageByApiReport(deprecatedApi, deprecatedUsages, outputDir, "usage-by-api", javadocUtil)
         };
 
         for (Report report : reports) {

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -46,8 +46,13 @@ public class Main {
     private static Map<String, Exception> createPluginsReport(UpdateCenter updateCenter) {
         final Map<String, Exception> errors = new TreeMap<>();
         for(JenkinsFile plugin : updateCenter.getPlugins()) {
+            Analysis analysis = new PluginAnalysis(plugin);
+            if (analysis.getDependentFiles(updateCenter).isEmpty()) {
+                System.out.println("No dependent plugin for " + analysis.getAnalyzedFileName());
+                continue;
+            }
             try {
-                createReport(updateCenter, new PluginAnalysis(plugin));
+                createReport(updateCenter, analysis);
             } catch (Exception ex) {
                 errors.put(plugin.getName(), ex);
             }

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -43,6 +43,10 @@ public class Main {
         final DeprecatedApi deprecatedApi = new DeprecatedApi();
         deprecatedApi.analyze(analyzedFile);
 
+        if (analysis.skipIfNoDeprecatedApis() && !deprecatedApi.hasDeprecatedApis()) {
+            System.out.println("No deprecated api found in " + analysis.getAnalyzedFileName());
+            return;
+        }
         System.out.println("Analyzing deprecated usage in " + analysis.getDependentFilesName());
         final List<DeprecatedUsage> deprecatedUsages = analyzeDeprecatedUsage(analysis.getDependentFiles(updateCenter), deprecatedApi);
 

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -91,23 +91,20 @@ public class Main {
                 .newFixedThreadPool(Runtime.getRuntime().availableProcessors());
         final List<Future<DeprecatedUsage>> futures = new ArrayList<>(plugins.size());
         for (final JenkinsFile plugin : plugins) {
-            final Callable<DeprecatedUsage> task = new Callable<DeprecatedUsage>() {
-                @Override
-                public DeprecatedUsage call() throws IOException {
-                    final DeprecatedUsage deprecatedUsage = new DeprecatedUsage(plugin.getName(),
-                            plugin.getVersion(), deprecatedApi);
-                    try {
-                        deprecatedUsage.analyze(plugin.getFile());
-                    } catch (final EOFException | ZipException e) {
-                        System.out.println("deleting " + plugin.getFile().getName() + " and skipping, because "
-                                + e.toString());
-                        plugin.getFile().delete();
-                    } catch (final Exception e) {
-                        System.out.println(e.toString() + " on " + plugin.getFile().getName());
-                        e.printStackTrace();
-                    }
-                    return deprecatedUsage;
+            final Callable<DeprecatedUsage> task = () -> {
+                final DeprecatedUsage deprecatedUsage = new DeprecatedUsage(plugin.getName(),
+                        plugin.getVersion(), deprecatedApi);
+                try {
+                    deprecatedUsage.analyze(plugin.getFile());
+                } catch (final EOFException | ZipException e) {
+                    System.out.println("deleting " + plugin.getFile().getName() + " and skipping, because "
+                            + e.toString());
+                    plugin.getFile().delete();
+                } catch (final Exception e) {
+                    System.out.println(e.toString() + " on " + plugin.getFile().getName());
+                    e.printStackTrace();
                 }
+                return deprecatedUsage;
             };
             futures.add(executorService.submit(task));
         }

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -108,6 +108,9 @@ public class Main {
         }
         executorService.shutdown();
         executorService.awaitTermination(5, TimeUnit.SECONDS);
+        if (i >= 10) {
+            System.out.println();
+        }
         // wait for threads to stop
         Thread.sleep(100);
         return deprecatedUsages;

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -73,7 +73,7 @@ public class Main {
         final List<DeprecatedUsage> deprecatedUsages = analyzeDeprecatedUsage(analysis.getDependentFiles(updateCenter), deprecatedApi);
 
         File outputDir = analysis.getOutputDirectory("output");
-        JavadocUtil javadocUtil = new JavadocUtil();
+        JavadocUtil javadocUtil = analysis.getJavadocUtil();
         Report[] reports = new Report[] {
                 new DeprecatedUsageByPluginReport(deprecatedApi, deprecatedUsages, outputDir, "usage-by-plugin", javadocUtil),
                 new DeprecatedUnusedApiReport(deprecatedApi, deprecatedUsages, outputDir, "deprecated-and-unused", javadocUtil, analysis.areSignatureFiltered()),

--- a/src/main/java/org/jenkinsci/deprecatedusage/PluginAnalysis.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/PluginAnalysis.java
@@ -1,0 +1,41 @@
+package org.jenkinsci.deprecatedusage;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PluginAnalysis implements Analysis {
+
+    private final JenkinsFile plugin;
+
+    public PluginAnalysis(JenkinsFile plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public String getAnalyzedFileName() {
+        return plugin.getName() + " plugin";
+    }
+
+    @Override
+    public JenkinsFile getAnalyzedFile(UpdateCenter updateCenter) {
+        return plugin;
+    }
+
+    @Override
+    public String getDependentFilesName() {
+        return plugin.getName() + " plugin dependencies";
+    }
+
+    @Override
+    public List<JenkinsFile> getDependentFiles(UpdateCenter updateCenter) {
+        return updateCenter.getPlugins().stream()
+            .filter(p -> p.isDependentOn(plugin))
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public File getOutputDirectory(String baseDir) {
+        return new File(baseDir, plugin.getName());
+    }
+}

--- a/src/main/java/org/jenkinsci/deprecatedusage/PluginAnalysis.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/PluginAnalysis.java
@@ -43,4 +43,9 @@ public class PluginAnalysis implements Analysis {
     public boolean areSignatureFiltered() {
         return false;
     }
+
+    @Override
+    public boolean skipIfNoDeprecatedApis() {
+        return true;
+    }
 }

--- a/src/main/java/org/jenkinsci/deprecatedusage/PluginAnalysis.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/PluginAnalysis.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 public class PluginAnalysis implements Analysis {
 
     private final JenkinsFile plugin;
+    private List<JenkinsFile> dependencies;
 
     public PluginAnalysis(JenkinsFile plugin) {
         this.plugin = plugin;
@@ -29,9 +30,12 @@ public class PluginAnalysis implements Analysis {
 
     @Override
     public List<JenkinsFile> getDependentFiles(UpdateCenter updateCenter) {
-        return updateCenter.getPlugins().stream()
-            .filter(p -> p.isDependentOn(plugin))
-            .collect(Collectors.toList());
+        if (dependencies == null) {
+            return updateCenter.getPlugins().stream()
+                .filter(p -> p.isDependentOn(plugin))
+                .collect(Collectors.toList());
+        }
+        return dependencies;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/deprecatedusage/PluginAnalysis.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/PluginAnalysis.java
@@ -52,4 +52,9 @@ public class PluginAnalysis implements Analysis {
     public boolean skipIfNoDeprecatedApis() {
         return true;
     }
+
+    @Override
+    public JavadocUtil getJavadocUtil() {
+        return JavadocUtil.PLUGINS;
+    }
 }

--- a/src/main/java/org/jenkinsci/deprecatedusage/PluginAnalysis.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/PluginAnalysis.java
@@ -38,4 +38,9 @@ public class PluginAnalysis implements Analysis {
     public File getOutputDirectory(String baseDir) {
         return new File(baseDir, plugin.getName());
     }
+
+    @Override
+    public boolean areSignatureFiltered() {
+        return false;
+    }
 }

--- a/src/main/java/org/jenkinsci/deprecatedusage/Report.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Report.java
@@ -14,12 +14,14 @@ public abstract class Report {
     protected final List<DeprecatedUsage> usages;
     protected final File outputDir;
     protected final String reportName;
+    protected final JavadocUtil javadocUtil;
 
-    public Report(DeprecatedApi api, List<DeprecatedUsage> usages, File outputDir, String reportName) {
+    public Report(DeprecatedApi api, List<DeprecatedUsage> usages, File outputDir, String reportName, JavadocUtil javadocUtil) {
         this.api = api;
         this.usages = usages;
         this.outputDir = outputDir;
         this.reportName = reportName;
+        this.javadocUtil = javadocUtil;
     }
 
     protected abstract void generateHtmlReport(Writer writer) throws IOException;

--- a/src/main/java/org/jenkinsci/deprecatedusage/Report.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Report.java
@@ -6,7 +6,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 

--- a/src/main/java/org/jenkinsci/deprecatedusage/UpdateCenter.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/UpdateCenter.java
@@ -6,13 +6,11 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.xml.sax.SAXException;
@@ -67,8 +65,15 @@ public class UpdateCenter {
         } else {
             wiki = null;
         }
+        final HashSet<String> dependencies = new HashSet<>();
+        if (jsonObject.has("dependencies")) {
+            JSONArray jsonDependencies = jsonObject.getJSONArray("dependencies");
+            for (int i = 0; i < jsonDependencies.length(); i++) {
+                dependencies.add(jsonDependencies.getJSONObject(i).getString("name"));
+            }
+        }
         return new JenkinsFile(jsonObject.getString("name"), jsonObject.getString("version"),
-                jsonObject.getString("url"), wiki);
+                jsonObject.getString("url"), wiki, dependencies);
     }
 
     public void download() throws Exception {

--- a/src/main/java/org/jenkinsci/deprecatedusage/UpdateCenter.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/UpdateCenter.java
@@ -59,15 +59,10 @@ public class UpdateCenter {
     }
 
     private JenkinsFile parse(JSONObject jsonObject) throws MalformedURLException, JSONException {
-        final String wiki;
-        if (jsonObject.has("wiki")) {
-            wiki = jsonObject.getString("wiki");
-        } else {
-            wiki = null;
-        }
+        final String wiki = jsonObject.optString("wiki");
         final HashSet<String> dependencies = new HashSet<>();
-        if (jsonObject.has("dependencies")) {
-            JSONArray jsonDependencies = jsonObject.getJSONArray("dependencies");
+        JSONArray jsonDependencies = jsonObject.optJSONArray("dependencies");
+        if (jsonDependencies != null) {
             for (int i = 0; i < jsonDependencies.length(); i++) {
                 dependencies.add(jsonDependencies.getJSONObject(i).getString("name"));
             }

--- a/src/main/java/org/jenkinsci/deprecatedusage/UpdateCenter.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/UpdateCenter.java
@@ -36,13 +36,8 @@ public class UpdateCenter {
             final JenkinsFile plugin = parse(jsonPlugin);
             plugins.add(plugin);
         }
-        final Comparator<JenkinsFile> comparator = new Comparator<JenkinsFile>() {
-            @Override
-            public int compare(JenkinsFile o1, JenkinsFile o2) {
-                return o1.getName().compareToIgnoreCase(o2.getName());
-            }
-        };
-        Collections.sort(plugins, comparator);
+        final Comparator<JenkinsFile> comparator = (o1, o2) -> o1.getName().compareToIgnoreCase(o2.getName());
+        plugins.sort(comparator);
     }
 
     private String getUpdateCenterJson() throws IOException, MalformedURLException {

--- a/src/test/java/org/jenkinsci/deprecatedusage/JavadocUtilTest.java
+++ b/src/test/java/org/jenkinsci/deprecatedusage/JavadocUtilTest.java
@@ -18,35 +18,35 @@ public class JavadocUtilTest {
         return Arrays.asList(new Object[][] {
             {
                 "hudson/util/RunList#size()I",
-                "http://javadoc.jenkins.io/hudson/util/RunList.html#size%28%29"
+                "http://javadoc.jenkins.io/hudson/util/RunList.html#size--"
             },
             {
                 "hudson/util/ChartUtil#generateGraph(Lorg/kohsuke/stapler/StaplerRequest;Lorg/kohsuke/stapler/StaplerResponse;Lorg/jfree/chart/JFreeChart;II)V",
-                "http://javadoc.jenkins.io/hudson/util/ChartUtil.html#generateGraph%28org.kohsuke.stapler.StaplerRequest,%20org.kohsuke.stapler.StaplerResponse,%20org.jfree.chart.JFreeChart,%20int,%20int%29"
+                "http://javadoc.jenkins.io/hudson/util/ChartUtil.html#generateGraph-org.kohsuke.stapler.StaplerRequest-org.kohsuke.stapler.StaplerResponse-org.jfree.chart.JFreeChart-int-int-"
             },
             {
                 "hudson/util/IOUtils#write([BLjava/io/OutputStream;)V",
-                "http://javadoc.jenkins.io/hudson/util/IOUtils.html#write%28byte[],%20java.io.OutputStream%29"
+                "http://javadoc.jenkins.io/hudson/util/IOUtils.html#write-byte:A-java.io.OutputStream-"
             },
             {
                 "hudson/Launcher#launch([Ljava/lang/String;[Ljava/lang/String;Ljava/io/InputStream;Ljava/io/OutputStream;Lhudson/FilePath;)Lhudson/Proc;",
-                "http://javadoc.jenkins.io/hudson/Launcher.html#launch%28java.lang.String[],%20java.lang.String[],%20java.io.InputStream,%20java.io.OutputStream,%20hudson.FilePath%29"
+                "http://javadoc.jenkins.io/hudson/Launcher.html#launch-java.lang.String:A-java.lang.String:A-java.io.InputStream-java.io.OutputStream-hudson.FilePath-"
             },
             {
                 "hudson/Launcher#launch(Ljava/lang/String;Ljava/util/Map;Ljava/io/OutputStream;Lhudson/FilePath;)Lhudson/Proc;",
-                "http://javadoc.jenkins.io/hudson/Launcher.html#launch%28java.lang.String,%20java.util.Map,%20java.io.OutputStream,%20hudson.FilePath%29"
+                "http://javadoc.jenkins.io/hudson/Launcher.html#launch-java.lang.String-java.util.Map-java.io.OutputStream-hudson.FilePath-"
             },
             {
                 "hudson/tools/ToolInstallation#<init>(Ljava/lang/String;Ljava/lang/String;)V",
-                "http://javadoc.jenkins.io/hudson/tools/ToolInstallation.html#ToolInstallation%28java.lang.String,%20java.lang.String%29"
+                "http://javadoc.jenkins.io/hudson/tools/ToolInstallation.html#ToolInstallation-java.lang.String-java.lang.String-"
             },
             {
                 "hudson/util/ChartUtil$NumberOnlyBuildLabel#<init>(Lhudson/model/AbstractBuild;)V",
-                "http://javadoc.jenkins.io/hudson/util/ChartUtil.NumberOnlyBuildLabel.html#ChartUtil.NumberOnlyBuildLabel%28hudson.model.AbstractBuild%29"
+                "http://javadoc.jenkins.io/hudson/util/ChartUtil.NumberOnlyBuildLabel.html#NumberOnlyBuildLabel-hudson.model.AbstractBuild-"
             },
             {
                 "hudson/slaves/DumbSlave#<init>(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lhudson/model/Node$Mode;Ljava/lang/String;Lhudson/slaves/ComputerLauncher;Lhudson/slaves/RetentionStrategy;Ljava/util/List;)V",
-                "http://javadoc.jenkins.io/hudson/slaves/DumbSlave.html#DumbSlave%28java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20hudson.model.Node.Mode,%20java.lang.String,%20hudson.slaves.ComputerLauncher,%20hudson.slaves.RetentionStrategy,%20java.util.List%29"
+                "http://javadoc.jenkins.io/hudson/slaves/DumbSlave.html#DumbSlave-java.lang.String-java.lang.String-java.lang.String-java.lang.String-hudson.model.Node.Mode-java.lang.String-hudson.slaves.ComputerLauncher-hudson.slaves.RetentionStrategy-java.util.List-"
             },
             {
                 "hudson/model/Build$RunnerImpl",
@@ -58,21 +58,21 @@ public class JavadocUtilTest {
             },
             {
                 "hudson/node_monitors/AbstractNodeMonitorDescriptor#<init>(J)V",
-                "http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor%28long%29"
+                "http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor-long-"
             },
             {
                 "hudson/model/MultiStageTimeSeries#<init>(FF)V",
-                "http://javadoc.jenkins.io/hudson/model/MultiStageTimeSeries.html#MultiStageTimeSeries%28float,%20float%29"
+                "http://javadoc.jenkins.io/hudson/model/MultiStageTimeSeries.html#MultiStageTimeSeries-float-float-"
             },
             {
                 // FAKED ONE, no public method in jenkins with a double found
                 "hudson/node_monitors/AbstractNodeMonitorDescriptor#<init>(D)V",
-                "http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor%28double%29"
+                "http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor-double-"
             },
             {
                 // FAKED ONE, no public method in jenkins with a short found
                 "hudson/node_monitors/AbstractNodeMonitorDescriptor#<init>(S)V",
-                "http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor%28short%29"
+                "http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor-short-"
             }
         });
     }

--- a/src/test/java/org/jenkinsci/deprecatedusage/JavadocUtilTest.java
+++ b/src/test/java/org/jenkinsci/deprecatedusage/JavadocUtilTest.java
@@ -1,55 +1,91 @@
 package org.jenkinsci.deprecatedusage;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
-import static org.jenkinsci.deprecatedusage.JavadocUtil.signatureToJenkinsdocUrl;
+import java.util.Arrays;
+import java.util.Collection;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.runners.Parameterized.*;
 
+@RunWith(Parameterized.class)
 public class JavadocUtilTest {
+
+    @Parameters(name = "testLinking({0})")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            {
+                "hudson/util/RunList#size()I",
+                "http://javadoc.jenkins.io/hudson/util/RunList.html#size%28%29"
+            },
+            {
+                "hudson/util/ChartUtil#generateGraph(Lorg/kohsuke/stapler/StaplerRequest;Lorg/kohsuke/stapler/StaplerResponse;Lorg/jfree/chart/JFreeChart;II)V",
+                "http://javadoc.jenkins.io/hudson/util/ChartUtil.html#generateGraph%28org.kohsuke.stapler.StaplerRequest,%20org.kohsuke.stapler.StaplerResponse,%20org.jfree.chart.JFreeChart,%20int,%20int%29"
+            },
+            {
+                "hudson/util/IOUtils#write([BLjava/io/OutputStream;)V",
+                "http://javadoc.jenkins.io/hudson/util/IOUtils.html#write%28byte[],%20java.io.OutputStream%29"
+            },
+            {
+                "hudson/Launcher#launch([Ljava/lang/String;[Ljava/lang/String;Ljava/io/InputStream;Ljava/io/OutputStream;Lhudson/FilePath;)Lhudson/Proc;",
+                "http://javadoc.jenkins.io/hudson/Launcher.html#launch%28java.lang.String[],%20java.lang.String[],%20java.io.InputStream,%20java.io.OutputStream,%20hudson.FilePath%29"
+            },
+            {
+                "hudson/Launcher#launch(Ljava/lang/String;Ljava/util/Map;Ljava/io/OutputStream;Lhudson/FilePath;)Lhudson/Proc;",
+                "http://javadoc.jenkins.io/hudson/Launcher.html#launch%28java.lang.String,%20java.util.Map,%20java.io.OutputStream,%20hudson.FilePath%29"
+            },
+            {
+                "hudson/tools/ToolInstallation#<init>(Ljava/lang/String;Ljava/lang/String;)V",
+                "http://javadoc.jenkins.io/hudson/tools/ToolInstallation.html#ToolInstallation%28java.lang.String,%20java.lang.String%29"
+            },
+            {
+                "hudson/util/ChartUtil$NumberOnlyBuildLabel#<init>(Lhudson/model/AbstractBuild;)V",
+                "http://javadoc.jenkins.io/hudson/util/ChartUtil.NumberOnlyBuildLabel.html#ChartUtil.NumberOnlyBuildLabel%28hudson.model.AbstractBuild%29"
+            },
+            {
+                "hudson/slaves/DumbSlave#<init>(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lhudson/model/Node$Mode;Ljava/lang/String;Lhudson/slaves/ComputerLauncher;Lhudson/slaves/RetentionStrategy;Ljava/util/List;)V",
+                "http://javadoc.jenkins.io/hudson/slaves/DumbSlave.html#DumbSlave%28java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20hudson.model.Node.Mode,%20java.lang.String,%20hudson.slaves.ComputerLauncher,%20hudson.slaves.RetentionStrategy,%20java.util.List%29"
+            },
+            {
+                "hudson/model/Build$RunnerImpl",
+                "http://javadoc.jenkins.io/hudson/model/Build.RunnerImpl.html"
+            },
+            {
+                "hudson/util/ChartUtil$NumberOnlyBuildLabel#build",
+                "http://javadoc.jenkins.io/hudson/util/ChartUtil.NumberOnlyBuildLabel.html#build"
+            },
+            {
+                "hudson/node_monitors/AbstractNodeMonitorDescriptor#<init>(J)V",
+                "http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor%28long%29"
+            },
+            {
+                "hudson/model/MultiStageTimeSeries#<init>(FF)V",
+                "http://javadoc.jenkins.io/hudson/model/MultiStageTimeSeries.html#MultiStageTimeSeries%28float,%20float%29"
+            },
+            {
+                // FAKED ONE, no public method in jenkins with a double found
+                "hudson/node_monitors/AbstractNodeMonitorDescriptor#<init>(D)V",
+                "http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor%28double%29"
+            },
+            {
+                // FAKED ONE, no public method in jenkins with a short found
+                "hudson/node_monitors/AbstractNodeMonitorDescriptor#<init>(S)V",
+                "http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor%28short%29"
+            }
+        });
+    }
+
+    @Parameter()
+    public String signature;
+
+    @Parameter(1)
+    public String expectedLink;
+
     @Test
     public void testLinking() {
-        assertEquals("http://javadoc.jenkins.io/hudson/util/RunList.html#size%28%29",
-                signatureToJenkinsdocUrl("hudson/util/RunList#size()I"));
-
-        assertEquals("http://javadoc.jenkins.io/hudson/util/ChartUtil.html#generateGraph%28org.kohsuke.stapler.StaplerRequest,%20org.kohsuke.stapler.StaplerResponse,%20org.jfree.chart.JFreeChart,%20int,%20int%29",
-                signatureToJenkinsdocUrl("hudson/util/ChartUtil#generateGraph(Lorg/kohsuke/stapler/StaplerRequest;Lorg/kohsuke/stapler/StaplerResponse;Lorg/jfree/chart/JFreeChart;II)V"));
-
-        assertEquals("http://javadoc.jenkins.io/hudson/util/IOUtils.html#write%28byte[],%20java.io.OutputStream%29",
-                signatureToJenkinsdocUrl("hudson/util/IOUtils#write([BLjava/io/OutputStream;)V"));
-
-        assertEquals("http://javadoc.jenkins.io/hudson/Launcher.html#launch%28java.lang.String[],%20java.lang.String[],%20java.io.InputStream,%20java.io.OutputStream,%20hudson.FilePath%29",
-                signatureToJenkinsdocUrl("hudson/Launcher#launch([Ljava/lang/String;[Ljava/lang/String;Ljava/io/InputStream;Ljava/io/OutputStream;Lhudson/FilePath;)Lhudson/Proc;"));
-
-        assertEquals("http://javadoc.jenkins.io/hudson/Launcher.html#launch%28java.lang.String,%20java.util.Map,%20java.io.OutputStream,%20hudson.FilePath%29",
-                signatureToJenkinsdocUrl("hudson/Launcher#launch(Ljava/lang/String;Ljava/util/Map;Ljava/io/OutputStream;Lhudson/FilePath;)Lhudson/Proc;"));
-
-        assertEquals("http://javadoc.jenkins.io/hudson/tools/ToolInstallation.html#ToolInstallation%28java.lang.String,%20java.lang.String%29",
-                signatureToJenkinsdocUrl("hudson/tools/ToolInstallation#<init>(Ljava/lang/String;Ljava/lang/String;)V"));
-
-        assertEquals("http://javadoc.jenkins.io/hudson/util/ChartUtil.NumberOnlyBuildLabel.html#ChartUtil.NumberOnlyBuildLabel%28hudson.model.AbstractBuild%29",
-                signatureToJenkinsdocUrl("hudson/util/ChartUtil$NumberOnlyBuildLabel#<init>(Lhudson/model/AbstractBuild;)V"));
-
-        assertEquals("http://javadoc.jenkins.io/hudson/slaves/DumbSlave.html#DumbSlave%28java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20hudson.model.Node.Mode,%20java.lang.String,%20hudson.slaves.ComputerLauncher,%20hudson.slaves.RetentionStrategy,%20java.util.List%29",
-                signatureToJenkinsdocUrl("hudson/slaves/DumbSlave#<init>(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lhudson/model/Node$Mode;Ljava/lang/String;Lhudson/slaves/ComputerLauncher;Lhudson/slaves/RetentionStrategy;Ljava/util/List;)V"));
-
-        assertEquals("http://javadoc.jenkins.io/hudson/model/Build.RunnerImpl.html",
-                signatureToJenkinsdocUrl("hudson/model/Build$RunnerImpl"));
-
-        assertEquals("http://javadoc.jenkins.io/hudson/util/ChartUtil.NumberOnlyBuildLabel.html#build",
-                signatureToJenkinsdocUrl("hudson/util/ChartUtil$NumberOnlyBuildLabel#build"));
-
-        assertEquals("http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor%28long%29",
-            signatureToJenkinsdocUrl("hudson/node_monitors/AbstractNodeMonitorDescriptor#<init>(J)V"));
-
-        assertEquals("http://javadoc.jenkins.io/hudson/model/MultiStageTimeSeries.html#MultiStageTimeSeries%28float,%20float%29",
-            signatureToJenkinsdocUrl("hudson/model/MultiStageTimeSeries#<init>(FF)V"));
-
-        // FAKED ONE, no public method in jenkins with a double found
-        assertEquals("http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor%28double%29",
-            signatureToJenkinsdocUrl("hudson/node_monitors/AbstractNodeMonitorDescriptor#<init>(D)V"));
-
-        // FAKED ONE, no public method in jenkins with a short found
-        assertEquals("http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor%28short%29",
-            signatureToJenkinsdocUrl("hudson/node_monitors/AbstractNodeMonitorDescriptor#<init>(S)V"));
+        assertEquals(expectedLink, new JavadocUtil().signatureToJenkinsdocUrl(signature));
+        System.out.println( new JavadocUtil().signatureToJenkinsdocUrl(signature));
     }
 }

--- a/src/test/java/org/jenkinsci/deprecatedusage/JavadocUtilTest.java
+++ b/src/test/java/org/jenkinsci/deprecatedusage/JavadocUtilTest.java
@@ -37,5 +37,19 @@ public class JavadocUtilTest {
 
         assertEquals("http://javadoc.jenkins.io/hudson/util/ChartUtil.NumberOnlyBuildLabel.html#build",
                 signatureToJenkinsdocUrl("hudson/util/ChartUtil$NumberOnlyBuildLabel#build"));
+
+        assertEquals("http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor%28long%29",
+            signatureToJenkinsdocUrl("hudson/node_monitors/AbstractNodeMonitorDescriptor#<init>(J)V"));
+
+        assertEquals("http://javadoc.jenkins.io/hudson/model/MultiStageTimeSeries.html#MultiStageTimeSeries%28float,%20float%29",
+            signatureToJenkinsdocUrl("hudson/model/MultiStageTimeSeries#<init>(FF)V"));
+
+        // FAKED ONE, no public method in jenkins with a double found
+        assertEquals("http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor%28double%29",
+            signatureToJenkinsdocUrl("hudson/node_monitors/AbstractNodeMonitorDescriptor#<init>(D)V"));
+
+        // FAKED ONE, no public method in jenkins with a short found
+        assertEquals("http://javadoc.jenkins.io/hudson/node_monitors/AbstractNodeMonitorDescriptor.html#AbstractNodeMonitorDescriptor%28short%29",
+            signatureToJenkinsdocUrl("hudson/node_monitors/AbstractNodeMonitorDescriptor#<init>(S)V"));
     }
 }

--- a/src/test/java/org/jenkinsci/deprecatedusage/JavadocUtilTest.java
+++ b/src/test/java/org/jenkinsci/deprecatedusage/JavadocUtilTest.java
@@ -85,7 +85,6 @@ public class JavadocUtilTest {
 
     @Test
     public void testLinking() {
-        assertEquals(expectedLink, new JavadocUtil().signatureToJenkinsdocUrl(signature));
-        System.out.println( new JavadocUtil().signatureToJenkinsdocUrl(signature));
+        assertEquals(expectedLink, JavadocUtil.CORE.signatureToJenkinsdocUrl(signature));
     }
 }


### PR DESCRIPTION
This proposal adds a dedicated report for each plugin having deprecated methods, providing the list of deprecated api used in dependant plugins (in the same form than the initial feature of reporting deprecated Jenkins api usage in plugins).
Each plugin with data to show will have a report in a repository named with the id of the plugin.

I also corrected the javadoc links to match the current version published on jenkins website.