### PR TITLE
Disable concurrent builds & discard old builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,8 @@ pipeline {
    }
 
    options {
+      disableConcurrentBuilds()
+      buildDiscarder(logRotator(daysToKeepStr: '90'))
       timeout(time: 1, unit: 'HOURS')
    }
 


### PR DESCRIPTION
For a periodically triggered job these settings should be applied to keep the load and history small.