### PR TITLE
Fix mirror download errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,13 @@
 			<artifactId>httpclient5</artifactId>
 			<version>5.0.1</version>
 		</dependency>
-		<dependency>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-jdk14</artifactId>
+                    <version>1.7.26</version>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>

--- a/src/main/java/org/jenkinsci/deprecatedusage/Checksum.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Checksum.java
@@ -1,18 +1,28 @@
 package org.jenkinsci.deprecatedusage;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
+import java.security.DigestException;
+import java.security.MessageDigest;
+import java.util.function.Function;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.StringUtils;
 
 @FunctionalInterface
 public interface Checksum {
 
-    boolean matches(byte[] data);
+    void check(byte[] data, String url) throws DigestException;
 
-    default boolean matches(Path file) throws IOException {
-        if (Files.notExists(file) || !Files.isRegularFile(file)) {
-            return false;
-        }
-        return matches(Files.readAllBytes(file));
+    static Checksum fromDigest(String kind, byte[] expectedDigest, Function<byte[], byte[]> digester) {
+        return (data, url) -> {
+            byte[] actualDigest = digester.apply(data);
+            if (!MessageDigest.isEqual(expectedDigest, actualDigest)) {
+                StringBuilder message = new StringBuilder(new StringBuilder().append("Wrong ").append(kind).append(" digest for ").append(url).append(" of length ").append(data.length).append(": expected ").append(Hex.encodeHexString(expectedDigest)).append(" but got ").append(Hex.encodeHexString(actualDigest)));
+                if (data.length < 1000) {
+                    message.append(" body: `").append(new String(data, StandardCharsets.ISO_8859_1)).append('`');
+                }
+                throw new DigestException(message.toString());
+            }
+        };
     }
+
 }

--- a/src/main/java/org/jenkinsci/deprecatedusage/JenkinsFile.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/JenkinsFile.java
@@ -86,7 +86,7 @@ public class JenkinsFile {
                 try {
                     byte[] data = result.getBodyBytes();
                     if (result.getCode() > 399) {
-                        future.completeExceptionally(new IOException(url + " failed : " + result.getCode() + new String(data, StandardCharsets.ISO_8859_1)));
+                        future.completeExceptionally(new IOException(url + " failed: " + result.getCode() + " " + new String(data, StandardCharsets.ISO_8859_1)));
                     }
                     if (checksum != null) {
                         try {

--- a/src/main/java/org/jenkinsci/deprecatedusage/JenkinsFile.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/JenkinsFile.java
@@ -8,6 +8,7 @@ import org.apache.hc.core5.concurrent.FutureCallback;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -84,6 +85,9 @@ public class JenkinsFile {
             public void completed(SimpleHttpResponse result) {
                 try {
                     byte[] data = result.getBodyBytes();
+                    if (result.getCode() > 399) {
+                        future.completeExceptionally(new IOException(url + " failed : " + result.getCode() + new String(data, StandardCharsets.ISO_8859_1)));
+                    }
                     if (checksum != null) {
                         try {
                             checksum.check(data, url);

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -83,7 +83,10 @@ public class Main {
         final long start = System.currentTimeMillis();
         final ExecutorService threadPool = Executors.newCachedThreadPool();
         HttpRequestRetryStrategy retryStrategy = new FlakyUpdateCenterRetryStrategy();
-        try (CloseableHttpAsyncClient client = HttpAsyncClients.custom().setRetryStrategy(retryStrategy).setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_1).build()) {
+        try (CloseableHttpAsyncClient client = HttpAsyncClients.custom().
+                setRetryStrategy(retryStrategy).
+                setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_1). // pending HTTPCLIENT-2113
+                build()) {
             final DeprecatedApi deprecatedApi = new DeprecatedApi();
             addClassesToAnalyze(deprecatedApi);
             List<String> updateCenterURLs = options.getUpdateCenterURLs();

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -10,6 +10,7 @@ import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http2.HttpVersionPolicy;
 import org.apache.hc.core5.util.TimeValue;
 import org.json.JSONObject;
 import org.kohsuke.args4j.CmdLineException;
@@ -82,7 +83,7 @@ public class Main {
         final long start = System.currentTimeMillis();
         final ExecutorService threadPool = Executors.newCachedThreadPool();
         HttpRequestRetryStrategy retryStrategy = new FlakyUpdateCenterRetryStrategy();
-        try (CloseableHttpAsyncClient client = HttpAsyncClients.custom().setRetryStrategy(retryStrategy).build()) {
+        try (CloseableHttpAsyncClient client = HttpAsyncClients.custom().setRetryStrategy(retryStrategy).setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_1).build()) {
             final DeprecatedApi deprecatedApi = new DeprecatedApi();
             addClassesToAnalyze(deprecatedApi);
             List<String> updateCenterURLs = options.getUpdateCenterURLs();

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -40,6 +40,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.zip.ZipException;
 
 public class Main {
@@ -63,6 +66,19 @@ public class Main {
             commandLineParser.printUsage(System.err);
             System.exit(0);
         }
+
+        if (options.verbose) {
+            // https://hc.apache.org/httpcomponents-client-5.0.x/logging.html
+            Logger l = Logger.getLogger("org.apache.hc.client5.http.headers");
+            l.setLevel(Level.ALL);
+            ConsoleHandler h = new ConsoleHandler();
+            h.setLevel(Level.ALL);
+            l.addHandler(h);
+            /* or turn on all of org.apache.hc.client5.http but exclude:
+            Logger.getLogger("org.apache.hc.client5.http.wire").setLevel(Level.INFO);
+            */
+        }
+
         final long start = System.currentTimeMillis();
         final ExecutorService threadPool = Executors.newCachedThreadPool();
         HttpRequestRetryStrategy retryStrategy = new FlakyUpdateCenterRetryStrategy();

--- a/src/main/java/org/jenkinsci/deprecatedusage/Options.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Options.java
@@ -58,6 +58,9 @@ public class Options {
     @Option(name = "-D", aliases = "--downloadConcurrent", metaVar = "COUNT", usage = "Specifies number of concurrent downloads to allow")
     public int maxConcurrentDownloads = Runtime.getRuntime().availableProcessors() * 4;
 
+    @Option(name = "-v", aliases = "--verbose", usage = "Add verbose logging about downloads")
+    public boolean verbose;
+
     private Options() {
     }
 

--- a/src/main/java/org/jenkinsci/deprecatedusage/UpdateCenter.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/UpdateCenter.java
@@ -35,10 +35,10 @@ public class UpdateCenter {
         final Checksum checksum;
         if (jsonObject.has("sha256")) {
             byte[] digest = decoder.decode(jsonObject.getString("sha256"));
-            checksum = data -> MessageDigest.isEqual(digest, DigestUtils.sha256(data));
+            checksum = Checksum.fromDigest("SHA-256", digest, DigestUtils::sha256);
         } else if (jsonObject.has("sha1")) {
             byte[] digest = decoder.decode(jsonObject.getString("sha1"));
-            checksum = data -> MessageDigest.isEqual(digest, DigestUtils.sha1(data));
+            checksum = Checksum.fromDigest("SHA-1", digest, DigestUtils::sha1);
         } else {
             checksum = null;
         }


### PR DESCRIPTION
Conversation with @daniel-beck. If I use the default UC I now get errors like

```
java.security.DigestException: Wrong SHA-256 digest for https://updates.jenkins.io/download/plugins/database/1.7/database.hpi of length 226: expected dfb983ebc835c4cfb4c11693c730513e96d91330bd0d4988938289ca70434a78 but got a5c402fa795aa7b38c40559c9d1e2904c1e049580e216b292466d6c0634e9ab6 body: `<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>400 Bad Request</title>
</head><body>
<h1>Bad Request</h1>
<p>Your browser sent a request that this server could not understand.<br />
</p>
</body></html>
`
```

or

```
java.security.DigestException: Wrong SHA-256 digest for https://updates.jenkins.io/download/plugins/btc-embeddedplatform/2.7.3/btc-embeddedplatform.hpi of length 166: expected 78d17d02c2e24177f47debbb3d819362b69b962eb6090a43d739d00f71b5884a but got a783b9c187c2177ce3a44c19f53b338134329b8995e4049b10fe204fc7cb1ae0 body: `<html>
<head><title>400 Bad Request</title></head>
<body>
<center><h1>400 Bad Request</h1></center>
<hr><center>nginx/1.18.0 (Ubuntu)</center>
</body>
</html>
`
```

or

```
java.security.DigestException: Wrong SHA-256 digest for https://updates.jenkins.io/download/plugins/octopusdeploy/3.0.3/octopusdeploy.hpi of length 291: expected 453146f6dba68bb6ec720264d7089d86f6bbb3a58d673e1eb3a72c416a46b95e but got c25e5e9837d5a5e2e3dc3c17477767b32bfba82e9bc29cd3144fe1613433a850 body: `<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>400 Bad Request</title>
</head><body>
<h1>Bad Request</h1>
<p>Your browser sent a request that this server could not understand.<br />
</p>
<hr>
<address>Apache Server at ftp.osuosl.org Port 443</address>
</body></html>
`
```