### PR TITLE
Use ASM6 opcode.

### DIFF
--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedApi.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedApi.java
@@ -92,7 +92,7 @@ public class DeprecatedApi {
         private String currentClass;
 
         CalledClassVisitor() {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM6);
         }
 
         private boolean isPublic(int asmAccess) {


### PR DESCRIPTION
The [`usage-in-plugins` job](https://ci.jenkins.io/job/Infra/job/usage-in-plugins/) has been failing for the past 29 days with this stack trace:

<details>
  <summary>Stack trace</summary>
  
```
java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.mojo.exec.ExecJavaMojo$1.run (ExecJavaMojo.java:293)
    at java.lang.Thread.run (Thread.java:748)
Caused by: java.util.concurrent.CompletionException: java.lang.UnsupportedOperationException: This feature requires ASM6
    at java.util.concurrent.CompletableFuture.encodeThrowable (CompletableFuture.java:273)
    at java.util.concurrent.CompletableFuture.completeThrowable (CompletableFuture.java:280)
    at java.util.concurrent.CompletableFuture.uniRun (CompletableFuture.java:722)
    at java.util.concurrent.CompletableFuture$UniRun.tryFire (CompletableFuture.java:701)
    at java.util.concurrent.CompletableFuture.postComplete (CompletableFuture.java:488)
    at java.util.concurrent.CompletableFuture.complete (CompletableFuture.java:1975)
    at org.jenkinsci.deprecatedusage.JenkinsFile$1Callback.completed (JenkinsFile.java:96)
    at org.jenkinsci.deprecatedusage.JenkinsFile$1Callback.completed (JenkinsFile.java:79)
    at org.apache.hc.core5.concurrent.BasicFuture.completed (BasicFuture.java:123)
    at org.apache.hc.core5.concurrent.ComplexFuture.completed (ComplexFuture.java:79)
    at org.apache.hc.client5.http.impl.async.InternalAbstractHttpAsyncClient$1$2$1.completed (InternalAbstractHttpAsyncClient.java:264)
    at org.apache.hc.core5.http.nio.support.AbstractAsyncResponseConsumer$2.completed (AbstractAsyncResponseConsumer.java:107)
    at org.apache.hc.core5.http.nio.entity.AbstractBinAsyncEntityConsumer.completed (AbstractBinAsyncEntityConsumer.java:84)
    at org.apache.hc.core5.http.nio.entity.AbstractBinDataConsumer.streamEnd (AbstractBinDataConsumer.java:81)
    at org.apache.hc.core5.http.nio.support.AbstractAsyncResponseConsumer.streamEnd (AbstractAsyncResponseConsumer.java:155)
    at org.apache.hc.client5.http.impl.async.HttpAsyncMainClientExec$1.streamEnd (HttpAsyncMainClientExec.java:233)
    at org.apache.hc.core5.http.impl.nio.ClientHttp1StreamHandler.dataEnd (ClientHttp1StreamHandler.java:281)
    at org.apache.hc.core5.http.impl.nio.ClientHttp1StreamDuplexer.dataEnd (ClientHttp1StreamDuplexer.java:369)
    at org.apache.hc.core5.http.impl.nio.AbstractHttp1StreamDuplexer.onInput (AbstractHttp1StreamDuplexer.java:315)
    at org.apache.hc.core5.http.impl.nio.AbstractHttp1IOEventHandler.inputReady (AbstractHttp1IOEventHandler.java:64)
    at org.apache.hc.core5.http.impl.nio.ClientHttp1IOEventHandler.inputReady (ClientHttp1IOEventHandler.java:39)
    at org.apache.hc.core5.reactor.ssl.SSLIOSession.decryptData (SSLIOSession.java:536)
    at org.apache.hc.core5.reactor.ssl.SSLIOSession.access$400 (SSLIOSession.java:71)
    at org.apache.hc.core5.reactor.ssl.SSLIOSession$1.inputReady (SSLIOSession.java:176)
    at org.apache.hc.core5.reactor.InternalDataChannel.onIOEvent (InternalDataChannel.java:124)
    at org.apache.hc.core5.reactor.InternalChannel.handleIOEvent (InternalChannel.java:51)
    at org.apache.hc.core5.reactor.SingleCoreIOReactor.processEvents (SingleCoreIOReactor.java:179)
    at org.apache.hc.core5.reactor.SingleCoreIOReactor.doExecute (SingleCoreIOReactor.java:128)
    at org.apache.hc.core5.reactor.AbstractSingleCoreIOReactor.execute (AbstractSingleCoreIOReactor.java:85)
    at org.apache.hc.core5.reactor.IOReactorWorker.run (IOReactorWorker.java:44)
    at java.lang.Thread.run (Thread.java:748)
Caused by: java.lang.UnsupportedOperationException: This feature requires ASM6
    at org.objectweb.asm.ClassVisitor.visitModule (ClassVisitor.java:143)
    at org.objectweb.asm.ClassReader.readModuleAttributes (ClassReader.java:755)
    at org.objectweb.asm.ClassReader.accept (ClassReader.java:554)
    at org.objectweb.asm.ClassReader.accept (ClassReader.java:401)
    at org.jenkinsci.deprecatedusage.DeprecatedApi.analyze (DeprecatedApi.java:65)
    at org.jenkinsci.deprecatedusage.DeprecatedApi.analyze (DeprecatedApi.java:56)
    at org.jenkinsci.deprecatedusage.Main.lambda$null$0 (Main.java:144)
    at java.util.concurrent.CompletableFuture.uniRun (CompletableFuture.java:719)
    at java.util.concurrent.CompletableFuture$UniRun.tryFire (CompletableFuture.java:701)
    at java.util.concurrent.CompletableFuture.postComplete (CompletableFuture.java:488)
    at java.util.concurrent.CompletableFuture.complete (CompletableFuture.java:1975)
    at org.jenkinsci.deprecatedusage.JenkinsFile$1Callback.completed (JenkinsFile.java:96)
    at org.jenkinsci.deprecatedusage.JenkinsFile$1Callback.completed (JenkinsFile.java:79)
    at org.apache.hc.core5.concurrent.BasicFuture.completed (BasicFuture.java:123)
    at org.apache.hc.core5.concurrent.ComplexFuture.completed (ComplexFuture.java:79)
    at org.apache.hc.client5.http.impl.async.InternalAbstractHttpAsyncClient$1$2$1.completed (InternalAbstractHttpAsyncClient.java:264)
    at org.apache.hc.core5.http.nio.support.AbstractAsyncResponseConsumer$2.completed (AbstractAsyncResponseConsumer.java:107)
    at org.apache.hc.core5.http.nio.entity.AbstractBinAsyncEntityConsumer.completed (AbstractBinAsyncEntityConsumer.java:84)
    at org.apache.hc.core5.http.nio.entity.AbstractBinDataConsumer.streamEnd (AbstractBinDataConsumer.java:81)
    at org.apache.hc.core5.http.nio.support.AbstractAsyncResponseConsumer.streamEnd (AbstractAsyncResponseConsumer.java:155)
    at org.apache.hc.client5.http.impl.async.HttpAsyncMainClientExec$1.streamEnd (HttpAsyncMainClientExec.java:233)
    at org.apache.hc.core5.http.impl.nio.ClientHttp1StreamHandler.dataEnd (ClientHttp1StreamHandler.java:281)
    at org.apache.hc.core5.http.impl.nio.ClientHttp1StreamDuplexer.dataEnd (ClientHttp1StreamDuplexer.java:369)
    at org.apache.hc.core5.http.impl.nio.AbstractHttp1StreamDuplexer.onInput (AbstractHttp1StreamDuplexer.java:315)
    at org.apache.hc.core5.http.impl.nio.AbstractHttp1IOEventHandler.inputReady (AbstractHttp1IOEventHandler.java:64)
    at org.apache.hc.core5.http.impl.nio.ClientHttp1IOEventHandler.inputReady (ClientHttp1IOEventHandler.java:39)
    at org.apache.hc.core5.reactor.ssl.SSLIOSession.decryptData (SSLIOSession.java:536)
    at org.apache.hc.core5.reactor.ssl.SSLIOSession.access$400 (SSLIOSession.java:71)
    at org.apache.hc.core5.reactor.ssl.SSLIOSession$1.inputReady (SSLIOSession.java:176)
    at org.apache.hc.core5.reactor.InternalDataChannel.onIOEvent (InternalDataChannel.java:124)
    at org.apache.hc.core5.reactor.InternalChannel.handleIOEvent (InternalChannel.java:51)
    at org.apache.hc.core5.reactor.SingleCoreIOReactor.processEvents (SingleCoreIOReactor.java:179)
    at org.apache.hc.core5.reactor.SingleCoreIOReactor.doExecute (SingleCoreIOReactor.java:128)
    at org.apache.hc.core5.reactor.AbstractSingleCoreIOReactor.execute (AbstractSingleCoreIOReactor.java:85)
    at org.apache.hc.core5.reactor.IOReactorWorker.run (IOReactorWorker.java:44)
    at java.lang.Thread.run (Thread.java:748)
```
</details>

I reproduced this problem locally and was able to resolve it by using the ASM 6 opcode when initializing `CalledClassVisitor`.