### PR TITLE
Add an option to scan plugin libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm</artifactId>
-			<version>8.0.1</version>
+			<version>9.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.json</groupId>

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUnusedApiReport.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUnusedApiReport.java
@@ -14,6 +14,7 @@ public class DeprecatedUnusedApiReport extends Report {
         super(api, usages, outputDir, reportName);
     }
 
+    @Override
     protected void generateHtmlReport(Writer writer) throws IOException {
         writer.append("<h1>Unused Deprecated APIs</h1>");
 
@@ -69,6 +70,7 @@ public class DeprecatedUnusedApiReport extends Report {
         }
     }
 
+    @Override
     protected void generateJsonReport(Writer writer) throws IOException {
         JSONObject obj = new JSONObject();
 

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
@@ -59,7 +59,12 @@ public class DeprecatedUsage {
         try (WarReader warReader = new WarReader(pluginFile, !includePluginLibraries)) {
             String fileName = warReader.nextClass();
             while (fileName != null) {
-                analyze(warReader.getInputStream(), aClassVisitor);
+                try (InputStream is = warReader.getInputStream()) {
+                    analyze(is, aClassVisitor);
+                } catch (Exception e) {
+                    System.err.println("Failed to fully analyze " + pluginFile + ".  " + fileName + " not scanned due to -> ");
+                    e.printStackTrace();
+                }
                 fileName = warReader.nextClass();
             }
         }

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
@@ -52,6 +52,7 @@ public class DeprecatedUsage {
         analyzeWithClassVisitor(pluginFile, classVisitor);
     }
 
+    
     public void analyzeWithClassVisitor(File pluginFile, ClassVisitor aClassVisitor)
             throws IOException {
         // recent plugins package their classes as a jar file with the same name as the war file in
@@ -59,7 +60,9 @@ public class DeprecatedUsage {
         try (WarReader warReader = new WarReader(pluginFile, !includePluginLibraries)) {
             String fileName = warReader.nextClass();
             while (fileName != null) {
-                try (InputStream is = warReader.getInputStream()) {
+                try {
+                    @SuppressWarnings("resource") // handled by warReader.nextClass()
+                    InputStream is = warReader.getInputStream();
                     analyze(is, aClassVisitor);
                 } catch (Exception e) {
                     System.err.println("Failed to fully analyze " + pluginFile + ".  " + fileName + " not scanned due to -> ");

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
@@ -228,7 +228,7 @@ public class DeprecatedUsage {
      */
     private class IndexerClassVisitor extends ClassVisitor {
         IndexerClassVisitor() {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM9);
         }
 
         @Override
@@ -260,7 +260,7 @@ public class DeprecatedUsage {
      */
     private class CallersClassVisitor extends ClassVisitor {
         CallersClassVisitor() {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM9);
         }
 
         @Override
@@ -276,7 +276,7 @@ public class DeprecatedUsage {
      */
     private class CallersMethodVisitor extends MethodVisitor {
         CallersMethodVisitor() {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM9);
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
@@ -235,8 +235,11 @@ public class DeprecatedUsage {
         public void visit(int version, int access, String name, String signature, String superName,
                 String[] interfaces) {
             // log(name + " extends " + superName + " {");
+            
             final List<String> superClassAndInterfaces = new ArrayList<>();
-            if (!isJavaClass(superName)) {
+            // superClass may be null for java.lang.Object and module-info.class
+            // Object would have been filtered but we see lots of module-info classes
+            if (superName != null && !isJavaClass(superName)) {
                 superClassAndInterfaces.add(superName);
             }
             if (interfaces != null) {

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
@@ -279,6 +279,7 @@ public class DeprecatedUsage {
             super(Opcodes.ASM9);
         }
 
+        @Deprecated
         @Override
         public void visitMethodInsn(int opcode, String owner, String name, String desc) {
             // log("\t" + owner + " " + name + " " + desc);

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
@@ -28,6 +28,7 @@ public class DeprecatedUsage {
 
     private final Plugin plugin;
     private final DeprecatedApi deprecatedApi;
+    private final boolean includePluginLibraries;
 
     private final Set<String> classes = new LinkedHashSet<>();
     private final Set<String> methods = new LinkedHashSet<>();
@@ -36,10 +37,11 @@ public class DeprecatedUsage {
     private final ClassVisitor classVisitor = new CallersClassVisitor();
     private final Map<String, List<String>> superClassAndInterfacesByClass = new HashMap<>();
 
-    public DeprecatedUsage(String pluginName, String pluginVersion, DeprecatedApi deprecatedApi) {
+    public DeprecatedUsage(String pluginName, String pluginVersion, DeprecatedApi deprecatedApi, boolean includePluginLibraries) {
         super();
         this.plugin = new Plugin(pluginName, pluginVersion);
         this.deprecatedApi = deprecatedApi;
+        this.includePluginLibraries = includePluginLibraries;
     }
 
     public void analyze(File pluginFile) throws IOException {
@@ -54,7 +56,7 @@ public class DeprecatedUsage {
             throws IOException {
         // recent plugins package their classes as a jar file with the same name as the war file in
         // WEB-INF/lib/ while older plugins were packaging their classes in WEB-INF/classes/
-        try (WarReader warReader = new WarReader(pluginFile, true)) {
+        try (WarReader warReader = new WarReader(pluginFile, !includePluginLibraries)) {
             String fileName = warReader.nextClass();
             while (fileName != null) {
                 analyze(warReader.getInputStream(), aClassVisitor);

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByApiReport.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByApiReport.java
@@ -73,6 +73,7 @@ public class DeprecatedUsageByApiReport extends Report {
         }
     }
 
+    @Override
     protected void generateHtmlReport(Writer writer) throws IOException {
         writer.append("<h1>Deprecated Usage in Plugins By API</h1>");
 
@@ -119,6 +120,7 @@ public class DeprecatedUsageByApiReport extends Report {
         }
     }
 
+    @Override
     protected void generateJsonReport(Writer writer) throws IOException {
         JSONObject map = new JSONObject();
 

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByPluginReport.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByPluginReport.java
@@ -19,6 +19,7 @@ public class DeprecatedUsageByPluginReport extends Report {
         super(api, usages, outputDir, reportName);
     }
 
+    @Override
     protected void generateHtmlReport(Writer writer) throws IOException {
         SortedSet<DeprecatedUsage> set = new TreeSet<>(Comparator.comparing(DeprecatedUsage::getPlugin));
         set.addAll(usages);
@@ -59,6 +60,7 @@ public class DeprecatedUsageByPluginReport extends Report {
         }
     }
 
+    @Override
     protected void generateJsonReport(Writer writer) throws IOException {
         JSONObject map = new JSONObject();
         for (DeprecatedUsage usage : usages) {

--- a/src/main/java/org/jenkinsci/deprecatedusage/HttpResponseException.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/HttpResponseException.java
@@ -3,6 +3,9 @@ package org.jenkinsci.deprecatedusage;
 import java.io.IOException;
 
 public class HttpResponseException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
     public HttpResponseException(int statusCode, String responseMessage) {
         super("HTTP " + statusCode + " " + responseMessage);
     }

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -108,7 +108,7 @@ public class Main {
             Collection<JenkinsFile> downloadedPlugins = downloader.synchronize(plugins).get();
 
             System.out.println("Analyzing usage in plugins");
-            final List<DeprecatedUsage> deprecatedUsages = analyzeDeprecatedUsage(downloadedPlugins, deprecatedApi, executor);
+            final List<DeprecatedUsage> deprecatedUsages = analyzeDeprecatedUsage(downloadedPlugins, deprecatedApi, executor, options.includePluginLibraries);
 
             Report[] reports = new Report[]{
                     new DeprecatedUsageByPluginReport(deprecatedApi, deprecatedUsages, new File("output"), "usage-by-plugin"),
@@ -142,12 +142,12 @@ public class Main {
     }
 
     private static List<DeprecatedUsage> analyzeDeprecatedUsage(Collection<JenkinsFile> plugins, DeprecatedApi deprecatedApi,
-                                                                Executor executor)
+                                                                Executor executor, boolean scanPluginLibs)
             throws InterruptedException, ExecutionException {
         List<CompletableFuture<DeprecatedUsage>> futures = new ArrayList<>();
         for (JenkinsFile plugin : plugins) {
             futures.add(CompletableFuture.supplyAsync(() -> {
-                DeprecatedUsage deprecatedUsage = new DeprecatedUsage(plugin.getName(), plugin.getVersion(), deprecatedApi);
+                DeprecatedUsage deprecatedUsage = new DeprecatedUsage(plugin.getName(), plugin.getVersion(), deprecatedApi, scanPluginLibs);
                 try {
                     deprecatedUsage.analyze(plugin.getFile());
                 } catch (final EOFException | ZipException | FileNotFoundException e) {

--- a/src/main/java/org/jenkinsci/deprecatedusage/Options.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Options.java
@@ -49,6 +49,9 @@ public class Options {
     @Option(name = "-i", aliases = "--onlyIncludeSpecified", usage = "Only include in the report the specified classes/methods/fields")
     public boolean onlyIncludeSpecified;
 
+    @Option(name = "-p", aliases = "--includePluginLibs", usage = "Also scan libraries bundled inside plugins")
+    public boolean includePluginLibraries;
+
     @Option(name = "--onlyIncludeJenkinsClasses", usage = "Only include in the report Jenkins related classes (jenkins.*, hudson.*, etc.")
     public boolean onlyIncludeJenkinsClasses;
 


### PR DESCRIPTION
it is possible to include Jars inside plugins that may also depend on
Jenkins, so add an option to include those in the scan as well.

This defaults to off to retain compatability with the old version,
however this may not be the correct way if people are looking at the
report of this as gospel.