### PR TITLE
Allow specifying a list of plugins to scan

### DIFF
--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.deprecatedusage;
 
+import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.json.JSONObject;
 import org.kohsuke.args4j.CmdLineException;
@@ -81,7 +82,7 @@ public class Main {
                         String json = IOUtils.toString(url, StandardCharsets.UTF_8).replace("updateCenter.post(", "");
                         UpdateCenter updateCenter = new UpdateCenter(new JSONObject(json));
                         cores.add(updateCenter.getCore());
-                        plugins.addAll(updateCenter.getPlugins());
+                        plugins.addAll(updateCenter.getPlugins().stream().filter(f -> Options.get().shouldScanPlugin(f.getName())).collect(Collectors.toSet()));
                         metadataLoaded.countDown();
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);

--- a/src/main/java/org/jenkinsci/deprecatedusage/Options.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Options.java
@@ -52,6 +52,9 @@ public class Options {
     @Option(name = "-p", aliases = "--includePluginLibs", usage = "Also scan libraries bundled inside plugins")
     public boolean includePluginLibraries;
 
+    @Option(name = "-P", aliases = "--onlyPlugins", usage = "Only scan plugins with the specified plugin IDs (comma separated)")
+    public String plugins;
+
     @Option(name = "--onlyIncludeJenkinsClasses", usage = "Only include in the report Jenkins related classes (jenkins.*, hudson.*, etc.")
     public boolean onlyIncludeJenkinsClasses;
 
@@ -73,6 +76,13 @@ public class Options {
             return Collections.singletonList(DEFAULT_UPDATE_CENTER_URL);
         }
         return Arrays.stream(urls).map(String::trim).collect(Collectors.toList());
+    }
+
+    public boolean shouldScanPlugin(String pluginId) {
+        if (plugins == null) {
+            return true;
+        }
+        return Arrays.stream(plugins.split(",")).map(String::trim).anyMatch(it -> it.equals(pluginId));
     }
 
     /**


### PR DESCRIPTION
Not particularly efficient, but doesn't really matter with just a few thousand plugins.

Usage:

```
java -jar target/deprecated-usage-in-plugins-0.1-SNAPSHOT-jar-with-dependencies.jar -P matrix-auth,credentials,credentials-binding
```