### PR TITLE
Look for `FilePath` fields in `Serializable` classes

### DIFF
--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByApiReport.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByApiReport.java
@@ -122,6 +122,7 @@ public class DeprecatedUsageByApiReport extends Report {
 
     @Override
     protected void generateJsonReport(Writer writer) throws IOException {
+        // TODO this library rewrites everything to an unsorted HashMap
         JSONObject map = new JSONObject();
 
         map.put("classes", deprecatedClassesToPlugins);

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByPluginReport.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsageByPluginReport.java
@@ -21,6 +21,7 @@ public class DeprecatedUsageByPluginReport extends Report {
 
     @Override
     protected void generateHtmlReport(Writer writer) throws IOException {
+        // TODO option to sort by https://stats.jenkins.io/plugin-installation-trend/latestNumbers.json
         SortedSet<DeprecatedUsage> set = new TreeSet<>(Comparator.comparing(DeprecatedUsage::getPlugin));
         set.addAll(usages);
 
@@ -64,6 +65,10 @@ public class DeprecatedUsageByPluginReport extends Report {
     protected void generateJsonReport(Writer writer) throws IOException {
         JSONObject map = new JSONObject();
         for (DeprecatedUsage usage : usages) {
+            if (!usage.hasDeprecatedUsage()) {
+                continue;
+            }
+
             JSONObject plugin = new JSONObject();
 
             plugin.put("plugin", usage.getPlugin().toString());


### PR DESCRIPTION
Recording for posterity some tooling used during https://github.com/jenkinsci/jenkins/pull/5880 research.

Note that this analysis has some limitations:
* Classes which only indirectly implement one of the listed interfaces will not be found.
* Fields which are of some serializable type that in turns includes a FilePath will not be found. For example https://github.com/jenkinsci/google-storage-plugin/blob/6618c8ef7c4a0eaf2f2bc8a0b48383667e2478e3/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java#L389-L397 actually uses https://github.com/jenkinsci/google-storage-plugin/blob/6618c8ef7c4a0eaf2f2bc8a0b48383667e2478e3/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java#L200 but this is not trivially seen.

Almost all false positives. https://github.com/jenkinsci/pipeline-utility-steps-plugin/blob/977b73fe4d9f8599f34b0dc53058eb1f2b33aeb1/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/zip/ZipStepExecution.java#L142 is a good example of a false positive in a widely used plugin: it would have been clearer to just pass a `String` for the path to the ZIP file in the workspace. We could consider adding a warning to https://github.com/jenkinsci/jenkins/blob/2c1c5ee20ea887c0e2aecf94b68cba6e7107740c/core/src/main/java/hudson/FilePath.java#L3266-L3283 whenever a `FilePath` is being sent to an agent, as such cases are potential preludes to S2MFC usage (when the object is not remote), though in most cases they are simply unnecessary complexity—the object is remote and you could write the M2S code to accept a `String`—or some other mistake, like use of an anonymous inner class for a callable. There are many such cases, so adding a stack trace would likely be too spammy for now.
