### PR TITLE
not all update centers define a core version, and not all update centers are http(s) based

### DIFF
--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -80,7 +80,9 @@ public class Main {
                     try {
                         String json = IOUtils.toString(url, StandardCharsets.UTF_8).replace("updateCenter.post(", "");
                         UpdateCenter updateCenter = new UpdateCenter(new JSONObject(json));
-                        cores.add(updateCenter.getCore());
+                        if (updateCenter.getCore() != null) {
+                            cores.add(updateCenter.getCore());
+                        }
                         plugins.addAll(updateCenter.getPlugins());
                         metadataLoaded.countDown();
                     } catch (IOException e) {

--- a/src/main/java/org/jenkinsci/deprecatedusage/UpdateCenter.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/UpdateCenter.java
@@ -14,7 +14,7 @@ public class UpdateCenter {
     private final List<JenkinsFile> plugins = new ArrayList<>();
 
     public UpdateCenter(JSONObject metadata) {
-        JSONObject jsonCore = metadata.getJSONObject("core");
+        JSONObject jsonCore = metadata.optJSONObject("core");
         core = parse(jsonCore);
         JSONObject jsonPlugins = metadata.getJSONObject("plugins");
         for (Object pluginId : jsonPlugins.keySet()) {
@@ -25,6 +25,9 @@ public class UpdateCenter {
     }
 
     private static JenkinsFile parse(JSONObject jsonObject) throws JSONException {
+        if (jsonObject == null) {
+            return null;
+        }
         final String wiki;
         if (jsonObject.has("wiki")) {
             wiki = jsonObject.getString("wiki");


### PR DESCRIPTION
An `UpdateCenter` does not have to be `http` based, nor does it have to define a core version, however the code assumed this was always the case.

make `core` definition in the update center optional, and allow file and http(s) based update centers.

@daniel-beck @timja 